### PR TITLE
Feat: Adicionando teste para a notificação DespesaCadastrada

### DIFF
--- a/app/Notifications/DespesaCadastrada.php
+++ b/app/Notifications/DespesaCadastrada.php
@@ -35,4 +35,9 @@ class DespesaCadastrada extends Notification
             ->line('Valor: R$ ' . number_format($this->despesa->valor, 2, ',', '.'))
             ->salutation('Atenciosamente, ' . config('app.name'));
     }
+
+    public function getDespesa()
+    {
+        return $this->despesa;
+    }
 }

--- a/tests/Feature/DespesaCadastradaTest.php
+++ b/tests/Feature/DespesaCadastradaTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Feature;
+
+use App\Models\Despesa;
+use App\Models\User;
+use App\Notifications\DespesaCadastrada;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class DespesaCadastradaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_notification_is_sent()
+    {
+        Notification::fake();
+
+        $despesa = Despesa::factory()->create();
+        $notifiable = User::factory()->create();
+        $notifiable->notify(new DespesaCadastrada($despesa));
+
+        Notification::assertSentTo(
+            $notifiable,
+            DespesaCadastrada::class,
+            function ($notification, $channels) use ($despesa) {
+                return $notification->getDespesa()->id === $despesa->id;
+            }
+        );
+    }
+}


### PR DESCRIPTION
Criado um teste de recurso `DespesaCadastradaTest` para garantir que a notificação `DespesaCadastrada` seja enviada corretamente. Além disso, foi adicionado um método `getDespesa` à classe de notificação `DespesaCadastrada` para facilitar as asserções no teste.